### PR TITLE
makes the original sqs message easier to access

### DIFF
--- a/lib/simple_sqs/events/base.rb
+++ b/lib/simple_sqs/events/base.rb
@@ -1,7 +1,9 @@
 class SimpleSqs::Events::Base
-  attr_reader :event
-  def initialize(event)
+  attr_reader :event, :message_attributes
+
+  def initialize(event, message_attributes = {})
     @event = event
+    @message_attributes = {}
   end
 
   def process

--- a/lib/simple_sqs/events/base.rb
+++ b/lib/simple_sqs/events/base.rb
@@ -1,9 +1,9 @@
 class SimpleSqs::Events::Base
-  attr_reader :event, :message_attributes
+  attr_reader :event, :sqs_message
 
-  def initialize(event, message_attributes = {})
+  def initialize(event, sqs_message = nil)
     @event = event
-    @message_attributes = {}
+    @sqs_message = sqs_message
   end
 
   def process

--- a/lib/simple_sqs/processor.rb
+++ b/lib/simple_sqs/processor.rb
@@ -6,26 +6,26 @@
 require 'logger'
 
 class SimpleSqs::Processor
-  def process_sqs_message sqs_message, message_attributes = {}
+  def process_sqs_message json_message_body, sqs_message = nil
     if Object.const_defined?("ActiveRecord")
       ActiveRecord::Base.transaction do
-        sqs_message['Events'].each do |event|
-          process event, message_attributes
+        json_message_body['Events'].each do |event|
+          process event, sqs_message
         end
       end
     else
-      sqs_message['Events'].each do |event|
-        process event, message_attributes
+      json_message_body['Events'].each do |event|
+        process event, sqs_message
       end
     end
   end
 
   private
-  def process event, message_attributes = {}
-    logger.debug "Processing SQS event #{event.inspect}, message attributes: #{message_attributes}"
+  def process event, sqs_message
+    logger.debug "Processing SQS event #{event.inspect}, raw message: #{sqs_message.inspect}"
     Librato.timing("sqs.process", source: event['EventType']) do
       klass = SIMPLE_SQS_EVENTS_NAMESPACE.const_get(event['EventType'])
-      sqs_event = klass.new(event.freeze, message_attributes)
+      sqs_event = klass.new(event.freeze, sqs_message)
 
       lag = ((Time.now - sqs_event.timestamp) * 1000).ceil
       Librato.measure("sqs.lag", lag, source: event['EventType'])

--- a/lib/simple_sqs/processor.rb
+++ b/lib/simple_sqs/processor.rb
@@ -6,26 +6,26 @@
 require 'logger'
 
 class SimpleSqs::Processor
-  def process_sqs_message sqs_message
+  def process_sqs_message sqs_message, message_attributes = {}
     if Object.const_defined?("ActiveRecord")
       ActiveRecord::Base.transaction do
         sqs_message['Events'].each do |event|
-          process event
+          process event, message_attributes
         end
       end
     else
       sqs_message['Events'].each do |event|
-        process event
+        process event, message_attributes
       end
     end
   end
 
   private
-  def process event
-    logger.debug "Processing SQS event #{event.inspect}"
+  def process event, message_attributes = {}
+    logger.debug "Processing SQS event #{event.inspect}, message attributes: #{message_attributes}"
     Librato.timing("sqs.process", source: event['EventType']) do
       klass = SIMPLE_SQS_EVENTS_NAMESPACE.const_get(event['EventType'])
-      sqs_event = klass.new(event.freeze)
+      sqs_event = klass.new(event.freeze, message_attributes)
 
       lag = ((Time.now - sqs_event.timestamp) * 1000).ceil
       Librato.measure("sqs.lag", lag, source: event['EventType'])

--- a/lib/simple_sqs/worker.rb
+++ b/lib/simple_sqs/worker.rb
@@ -45,20 +45,14 @@ class SimpleSqs::Worker
   end
 
   def process(message)
-    json_message = MultiJson.decode(message.body)
+    json_message_body = MultiJson.decode(message.body)
     begin
-      processor.process_sqs_message(json_message, message_attributes(message))
+      processor.process_sqs_message(json_message_body, message)
     rescue Exception => e
       logger.error "SQS: #{message.message_id}\t#{e.message}\t#{e.backtrace}"
       Librato.increment('sqs.error')
       handle_message_error(message, exception: e)
     end
-  end
-
-  def message_attributes(message)
-    {
-      approximate_receive_count: message.attributes['ApproximateReceiveCount']
-    }
   end
 
   def handle_message_error(message, exception: nil)

--- a/lib/simple_sqs/worker.rb
+++ b/lib/simple_sqs/worker.rb
@@ -47,12 +47,18 @@ class SimpleSqs::Worker
   def process(message)
     json_message = MultiJson.decode(message.body)
     begin
-      processor.process_sqs_message(json_message)
+      processor.process_sqs_message(json_message, message_attributes(message))
     rescue Exception => e
       logger.error "SQS: #{message.message_id}\t#{e.message}\t#{e.backtrace}"
       Librato.increment('sqs.error')
       handle_message_error(message, exception: e)
     end
+  end
+
+  def message_attributes(message)
+    {
+      approximate_receive_count: message.attributes['ApproximateReceiveCount']
+    }
   end
 
   def handle_message_error(message, exception: nil)

--- a/spec/simple_sqs/processor_spec.rb
+++ b/spec/simple_sqs/processor_spec.rb
@@ -2,15 +2,24 @@ require 'spec_helper'
 require_relative '../../dummy_app/sqs/events/some_event'
 
 describe SimpleSqs::Processor do
+  SIMPLE_SQS_EVENTS_NAMESPACE = DummyApp::Sqs::Events
+
   let(:sqs) { described_class.new }
   let(:hit) {  @hit || create(:hit_aws) }
   let(:worker) {  @worker || create(:worker) }
 
   describe ".process_sqs_message" do
     it 'loads the appropriate class and process it' do
-      SIMPLE_SQS_EVENTS_NAMESPACE = DummyApp::Sqs::Events
       DummyApp::Sqs::Events::SomeEvent.any_instance.should_receive(:process)
       described_class.new.process_sqs_message fake_sqs_message('SomeEvent', Time.now)
+    end
+
+    it 'passes the proper data to the processor' do
+      event = fake_sqs_message('SomeEvent', Time.now)
+      message_attrs = { approximate_receive_count: 2 }
+      DummyApp::Sqs::Events::SomeEvent.should_receive(:new).with(event['Events'][0], message_attrs).and_call_original
+      DummyApp::Sqs::Events::SomeEvent.any_instance.should_receive(:process)
+      described_class.new.process_sqs_message event, message_attrs
     end
   end
 end

--- a/spec/simple_sqs/worker_spec.rb
+++ b/spec/simple_sqs/worker_spec.rb
@@ -38,7 +38,7 @@ describe SimpleSqs::Worker do
     end
 
     it 'passes through the approximate receive count' do
-      subject.processor.should receive(:process_sqs_message).with({ "Events" => [{}] }, { :approximate_receive_count => "1"})
+      subject.processor.should receive(:process_sqs_message).with({ "Events" => [{}] }, message)
       subject.send(:process, message)
     end
 

--- a/spec/simple_sqs/worker_spec.rb
+++ b/spec/simple_sqs/worker_spec.rb
@@ -37,6 +37,11 @@ describe SimpleSqs::Worker do
       end
     end
 
+    it 'passes through the approximate receive count' do
+      subject.processor.should receive(:process_sqs_message).with({ "Events" => [{}] }, { :approximate_receive_count => "1"})
+      subject.send(:process, message)
+    end
+
     context 'when there is an error' do
       it 'raises the exception to Sentry/Raven' do
         expect(Raven).to receive(:capture_exception)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'simple_sqs'
+require 'byebug'
 require_relative './support/simple_sqs_test_helpers'


### PR DESCRIPTION
this looks into exposing the original sqs message to the event processors. to make it easier to reference data on the original message object. 