### PR TITLE
default these env vars for specs

### DIFF
--- a/lib/simple_sqs.rb
+++ b/lib/simple_sqs.rb
@@ -7,6 +7,7 @@ require "simple_sqs/queue"
 require "sentry-raven"
 require "librato-rails"
 require "aws-sdk"
+require 'multi_json'
 
 module SimpleSqs
   # Your code goes here...

--- a/simple_sqs.gemspec
+++ b/simple_sqs.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk"
   spec.add_dependency "librato-rails"
   spec.add_dependency "sentry-raven"
+  spec.add_dependency "multi_json"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'simple_sqs'
+require 'byebug'
 require_relative './support/simple_sqs_test_helpers'

--- a/spec/support/simple_sqs_test_helpers.rb
+++ b/spec/support/simple_sqs_test_helpers.rb
@@ -19,3 +19,8 @@ end
 RSpec.configure do |config|
   config.include SimpleSqsHelpers
 end
+
+ENV['SIMPLE_SQS_QUEUE_URL'] ||= 'fake'
+ENV['SIMPLE_SQS_PUBLIC_KEY'] ||= 'fake'
+ENV['SIMPLE_SQS_SECRET_KEY'] ||= 'fake'
+ENV['SIMPLE_SQS_REGION'] ||= 'us-east-1'


### PR DESCRIPTION
so we don't have to explicitly define them to
run the suite.