### PR TITLE
[RF-19521] Move CI to Circle, test against modern Rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,87 @@
+version: 2.1
+
+jobs:
+  test:
+    parameters:
+      ruby:
+        type: string
+    docker:
+      - image: cimg/ruby:<< parameters.ruby >>
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - run:
+          name: Install Ruby gems
+          command: |
+            bundle config set --local path 'vendor/bundle'
+            bundle check || bundle install --jobs=4 --retry=3
+      - run:
+          name: Set up test output directory
+          command: sudo install -o circleci -d ~/rspec
+      - run:
+          name: RSpec
+          command: |
+            bundle exec rspec \
+              --color \
+              --require spec_helper \
+              --format documentation \
+              --format RspecJunitFormatter \
+              --out ~/rspec/rspec.xml
+  push_to_rubygems:
+    docker:
+      - image: cimg/ruby:3.1.2
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - run:
+          name: Create .gem/credentials file
+          command: |
+            mkdir ~/.gem
+            echo "---
+              :rubygems_api_key: $RUBYGEMS_API_KEY
+            " > ~/.gem/credentials
+            chmod 600 ~/.gem/credentials
+      - run:
+          name: Release simple_sqs
+          command: |
+            gem build simple_sqs
+            gem push simple_sqs-*.gem
+
+workflows:
+  test_and_deploy:
+    jobs:
+      - test:
+          matrix:
+            alias: old-ruby
+            parameters:
+              ruby: ["2.7.6", "3.0.4"]
+          filters:
+            tags:
+              only:
+                - /^v.*/
+          context:
+            - DockerHub
+      - test:
+          ruby: "3.1.2"
+          filters:
+            tags:
+              only:
+                - /^v.*/
+          context:
+            - DockerHub
+      - push_to_rubygems:
+          requires:
+            - test
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v.*/
+          context:
+            - DockerHub

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 2.3.1@simple_sqs --create

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export SIMPLE_SQS_NO_AR_TRANSACTION=true
 
 ### Librato prefix
 
-If you have multiple apps using SimpleSqs that all logs to the same Librato account, it is higly suggested to configure each app with a [custom prefix](https://github.com/librato/librato-rails#custom-prefixes).
+If you have multiple apps using SimpleSqs that all logs to the same Librato account, it is higly suggested to configure each app with a [custom prefix](https://github.com/librato/librato-rails#custom-prefixes). Support is provided for Librato accounts using [sources, not tags](https://www.librato.com/docs/kb/faq/account_questions/tags_or_sources/).
 
 ### Rake task
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SimpleSqs
 
-[![Build Status](https://travis-ci.org/rainforestapp/simple_sqs.svg)](https://travis-ci.org/rainforestapp/simple_sqs)
+[![rainforestapp](https://circleci.com/gh/rainforestapp/simple_sqs.svg?style=svg)](https://circleci.com/gh/rainforestapp/simple_sqs)
 
 SimpleSqs is a super simple abstraction of SQS. You can have a daemon polling and running jobs for messages, and enqueue some messages too. It was developed by Rainforest QA, a [web app testing](https://www.rainforestqa.com/product/web-app-testing/) platform.
 

--- a/simple_sqs.gemspec
+++ b/simple_sqs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk"
-  spec.add_dependency "librato-rails"
+  spec.add_dependency "librato-rails", "~> 1"
   spec.add_dependency "sentry-raven"
   spec.add_dependency "multi_json"
   spec.add_development_dependency "rake"

--- a/simple_sqs.gemspec
+++ b/simple_sqs.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "byebug"
 end


### PR DESCRIPTION
`.circleci/config.yml` is essentially copy-pasted from `rainforestapp/get_env` (see https://github.com/rainforestapp/get_env/pull/86).